### PR TITLE
Update to latestest Quarkus version requires additonal dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <version>0.1.0</version>
   <properties>
     <surefire-plugin.version>2.22.0</surefire-plugin.version>
-    <quarkus.version>0.15.0</quarkus.version>
+    <quarkus.version>0.26.1</quarkus.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
@@ -43,6 +43,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jsonb</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-undertow</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Since the latest quarkus versions the AngularRouteFilter.java example (as referenced in https://quarkus.io/blog/quarkus-and-web-ui-development-mode/) is no longer compiling as the dependency to quarkus-undertow is missing.
I have update the pom.xml to the latest quarkus version and added the missing dependency.