### PR TITLE
404 issue

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -229,7 +229,9 @@ public class AngularRouteFilter extends HttpFilter {
                     request.getContextPath().length()).replaceAll("[/]+$", "");
             if (!FILE_NAME_PATTERN.matcher(path).matches()) {
                 // We could not find the resource, i.e. it is not anything known to the server (i.e. it is not a REST
-                // endpoint or a servlet), and does not look like a file so try handling it in the front-end routes.
+                // endpoint or a servlet), and does not look like a file so try handling it in the front-end routes
+                // and reset the response status code to 200.
+                response.setStatus(200);    
                 request.getRequestDispatcher("/").forward(request, response);
             }
         }

--- a/src/main/java/org/kabir/quarkus/ui/AngularRouteFilter.java
+++ b/src/main/java/org/kabir/quarkus/ui/AngularRouteFilter.java
@@ -31,7 +31,9 @@ public class AngularRouteFilter extends HttpFilter {
                     request.getContextPath().length()).replaceAll("[/]+$", "");
             if (!FILE_NAME_PATTERN.matcher(path).matches()) {
                 // We could not find the resource, i.e. it is not anything known to the server (i.e. it is not a REST
-                // endpoint or a servlet), and does not look like a file so try handling it in the front-end routes.
+                // endpoint or a servlet), and does not look like a file so try handling it in the front-end routes
+                // and reset the response status code to 200.
+                response.setStatus(200);    
                 request.getRequestDispatcher("/").forward(request, response);
             }
         }


### PR DESCRIPTION
In the AngularRouteFilter, a 404 request is dispatched to the the frontend router.  This change resets the HTTP status code back to 200.  Otherwise, the frontend resource will be served with a 404 status.